### PR TITLE
Fix build with cpputest

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,14 +33,20 @@ FetchContent_MakeAvailable(ArduinoFake)
 
 add_executable(first_test AllTests.cpp MyFirstTest.cpp)
 
-target_link_libraries(first_test PRIVATE
-    CppUTest::CppUTest
-    CppUTest::CppUTestExt
-    ArduinoFake
-    FakeIt-standalone)
-
 target_include_directories(first_test PUBLIC
     "build/_deps/arduinofake-src/src"
     "build/_deps/fakeit-src/include/fakeit"
     "includes"
+)
+
+target_compile_options(first_test PUBLIC
+    "$<$<COMPILE_LANGUAGE:C,CXX>:-includeMyMemoryLeakDetectorNewMacrosFile.h>"
+    "$<$<COMPILE_LANGUAGE:CXX>:-includeMyMemoryLeakDetectorNewMacrosFile.h>"
+)
+
+target_link_libraries(first_test PRIVATE
+    CppUTest::CppUTest
+    CppUTest::CppUTestExt
+    ArduinoFake
+    FakeIt-standalone
 )


### PR DESCRIPTION
If you look at the compile commands for MyFirstTest.cpp, you can see:
- `-includeCppUTest/MemoryLeakDetectorMallocMacros.h`
- `-includeCppUTest/MemoryLeakDetectorNewMacros.h`

These flags force inclusion of these headers before any includes defined in the source file. These come from CppUTest:
https://github.com/cpputest/cpputest/blob/c3625dc668b4be4a1639e7e81f681e7d709a7b93/src/CppUTest/CMakeLists.txt#L100-L104

It's not sufficient to include `MyMemoryLeakDetectorNewMacrosFile.h` in your source because the forced inclusions will happen first. The way to solve this is to force inclusion of your header first as I've done here.

This is detailed in the CppUTest manual:
https://cpputest.github.io/manual.html#conflicts-with-operator-new-macros-stl